### PR TITLE
Refactor to get caught up with latest plugin template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{md,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: bug
+assignees: ""
+---
+
+**Describe the bug**
+
+<!-- A clear and concise description of what the bug is. -->
+
+**Steps to reproduce**
+
+<!-- Steps to reproduce the behavior: -->
+
+**Expected behavior**
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST/pull_request_template.md
+++ b/.github/PULL_REQUEST/pull_request_template.md
@@ -1,0 +1,34 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## Types of changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Usage examples
+
+<!--- Provide examples of intended usage -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+
+## Checklist
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  plugin_test:
+    name: asdf plugin test
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: asdf_plugin_test
+        uses: asdf-vm/actions/plugin-test@v2
+        with:
+          command: doctl version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: asdf-vm/actions/install@v2
+      - run: scripts/lint.bash
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.6.23
+        with:
+          args: -color

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,14 +10,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: asdf-vm/actions/install@v2
       - run: scripts/lint.bash
 
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check workflow files
         uses: docker://rhysd/actionlint:1.6.23
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3
+      - uses: GoogleCloudPlatform/release-please-action@v4
         with:
           release-type: simple

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v3
+        with:
+          release-type: simple

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  semantic-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.5.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: true

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+shellcheck 0.9.0
+shfmt 3.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: c
-script: asdf plugin-test doctl $TRAVIS_BUILD_DIR 'doctl version'
-before_script:
-  - git clone https://github.com/asdf-vm/asdf.git
-  - . asdf/asdf.sh
-os:
-  - linux
-  - osx

--- a/README.md
+++ b/README.md
@@ -1,15 +1,52 @@
-# asdf-doctl
+<div align="center">
 
-[![Build Status](https://travis-ci.org/maristgeek/asdf-doctl.svg?branch=master)](https://travis-ci.org/maristgeek/asdf-doctl)
+# asdf-doctl [![Build](https://github.com/bstoutenburgh/asdf-doctl/actions/workflows/build.yml/badge.svg)](https://github.com/bstoutenburgh/asdf-doctl/actions/workflows/build.yml) [![Lint](https://github.com/bstoutenburgh/asdf-doctl/actions/workflows/lint.yml/badge.svg)](https://github.com/bstoutenburgh/asdf-doctl/actions/workflows/lint.yml)
 
-[doctl](https://github.com/digitalocean/doctl) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager. Check doctl's README for latest supported installation options but if they do not suit your needs this can work for 1.21.1+.
+[doctl](https://github.com/digitalocean/doctl)  plugin for the [asdf version manager](https://asdf-vm.com). Check doctl's README for latest supported installation options but if they do not suit your needs this can work for 1.21.1+.
 
-## Install
+</div>
+
+# Contents
+
+- [Install](#install)
+- [Contributing](#contributing)
+- [License](#license)
+
+# Install
+
+Plugin:
 
 ```shell
-asdf plugin-add doctl https://github.com/maristgeek/asdf-doctl.git
+asdf plugin add doctl
+# or
+asdf plugin add doctl https://github.com/bstoutenburgh/asdf-doctl.git
 ```
 
-## Use
+doctl:
 
-Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install & manage versions of doctl.
+```shell
+# Show all installable versions
+asdf list-all doctl
+
+# Install specific version
+asdf install doctl latest
+
+# Set a version globally (on your ~/.tool-versions file)
+asdf global doctl latest
+
+# Now doctl commands are available
+doctl help
+```
+
+Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to
+install & manage versions.
+
+# Contributing
+
+Contributions of any kind welcome! See the [contributing guide](contributing.md).
+
+[Thanks goes to these contributors](https://github.com/bstoutenburgh/asdf-doctl/graphs/contributors)!
+
+# License
+
+See [LICENSE](LICENSE) © [Ben Stoutenburgh](https://github.com/bstoutenburgh/)

--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=./lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+mkdir -p "$ASDF_DOWNLOAD_PATH"
+
+release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
+
+# Download tar.gz file to the download directory
+download_release "$ASDF_INSTALL_VERSION" "$release_file"
+
+#  Extract contents of tar.gz file into the download directory
+tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+
+# Remove the tar.gz file since we don't need to keep it
+rm "$release_file"

--- a/bin/install
+++ b/bin/install
@@ -1,74 +1,11 @@
 #!/usr/bin/env bash
 
-set -e
-set -o pipefail
+set -euo pipefail
 
-install_doctl() {
-  local -r version=$2
-  local -r install_path=$3
-  local -r tmp_download_dir=$4
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-  local -r bin_install_path="${install_path}/bin"
-  local -r binary_path="${bin_install_path}/doctl"
+# shellcheck source=./lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
 
-  local platform
-  local arch
-  local download_url
-  local download_path
-
-  platform=$(get_platform)
-  arch=$(get_arch)
-  download_url=$(get_download_url "$version" "$platform" "$arch")
-  download_path="${tmp_download_dir}"/$(get_filename "$version" "$platform" "$arch")
-
-  echo "Downloading doctl from ${download_url}"
-  curl -Lo "${download_path}" "${download_url}"
-
-  echo "Creating bin directory"
-  mkdir -p "${bin_install_path}"
-
-  echo "Cleaning previous binaries"
-  rm -f "${binary_path}" 2>/dev/null || true
-
-  echo "Copying binary"
-  tar xf "${download_path}" -C "${bin_install_path}"
-  chmod +x "${binary_path}"
-
-  echo "Cleaning up downloads"
-  rm -f "${download_path}"
-}
-
-get_platform() {
-  uname | tr '[:upper:]' '[:lower:]'
-}
-
-get_arch() {
-    local arch=$(uname -m)
-    if [ "$arch" = "x86_64" ]; then
-        arch="amd64"
-    fi
-    echo $arch
-}
-
-get_filename() {
-  local -r version=$1
-  local -r platform=$2
-  local -r arch=$3
-
-  echo "doctl-${version}-${platform}-${arch}.tar.gz"
-}
-
-get_download_url() {
-  local -r version=$1
-  local -r platform=$2
-  local -r arch=$3
-  local filename
-  filename=$(get_filename "$version" "$platform" "$arch")
-
-  echo "https://github.com/digitalocean/doctl/releases/download/v${version}/${filename}"
-}
-
-# probably should verify ASDF_INSTALL_VERSION is 1.21.1+
-tmp_download_dir="$(mktemp -d -t 'asdf_XXXXXXXX')"
-trap 'rm -rf "${tmp_download_dir}"' EXIT
-install_doctl "${ASDF_INSTALL_TYPE}" "${ASDF_INSTALL_VERSION}" "${ASDF_INSTALL_PATH}" "$tmp_download_dir"
+install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=./lib/utils.bash
+. "${plugin_dir}/lib/utils.bash"
+
+curl_opts=(-sI)
+
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+fi
+
+# curl of REPO/releases/latest is expected to be a 302 to another URL
+# when no releases redirect_url="REPO/releases"
+# when there are releases redirect_url="REPO/releases/tag/v<VERSION>"
+redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | sed -n -e "s|\r||p")
+version=
+printf "redirect url: %s\n" "$redirect_url" >&2
+if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
+	version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
+else
+	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
+fi
+
+printf "%s\n" "$version"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,19 +1,11 @@
 #!/usr/bin/env bash
 
-releases_path=https://api.github.com/repos/digitalocean/doctl/releases
-cmd="curl -s"
-if [ -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
-fi
-cmd="$cmd $releases_path"
+# set -euo pipefail
 
-# stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
-function sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval "${cmd}" | grep -oE 'tag_name\":\s?\"v.{1,15}\",' | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
-# shellcheck disable=SC2086
-echo $versions
+# shellcheck source=./lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+list_all_versions | sort_versions | xargs echo

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,11 @@
+# Contributing
+
+Testing Locally:
+
+```shell
+asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
+
+asdf plugin test doctl https://github.com/bstoutenbiurgh/asdf-doctl.git "doctl version"
+```
+
+Tests are automatically run in GitHub Actions on push and PR.

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# TODO: Ensure this is the correct GitHub homepage where releases can be downloaded for <YOUR TOOL>.
+GH_REPO="https://github.com/digitalocean/doctl"
+TOOL_NAME="doctl"
+TOOL_TEST="doctl version"
+
+fail() {
+	echo -e "asdf-$TOOL_NAME: $*"
+	exit 1
+}
+
+curl_opts=(-fsSL)
+
+# NOTE: You might want to remove this if <YOUR TOOL> is not hosted on GitHub releases.
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+fi
+
+sort_versions() {
+	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
+
+list_github_tags() {
+	git ls-remote --tags --refs "$GH_REPO" |
+		grep -o 'refs/tags/.*' | cut -d/ -f3- |
+		grep -v '^[^v]' | # remove tags 1, prototype-1 and anything else that does not start with v
+		sed 's/^v//'
+}
+
+list_all_versions() {
+	list_github_tags
+}
+
+download_release() {
+	local version filename url
+	version="$1"
+	filename="$2"
+
+	# TODO: Adapt the release URL convention for <YOUR TOOL>
+	url="$GH_REPO/archive/v${version}.tar.gz"
+
+	echo "* Downloading $TOOL_NAME release $version..."
+	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
+}
+
+install_version() {
+	local install_type="$1"
+	local version="$2"
+	local install_path="${3%/bin}/bin"
+
+	if [ "$install_type" != "version" ]; then
+		fail "asdf-$TOOL_NAME supports release installs only"
+	fi
+
+	(
+		mkdir -p "$install_path"
+		cp -r "$ASDF_DOWNLOAD_PATH"/* "$install_path"
+
+		# TODO: Assert <YOUR TOOL> executable exists.
+		local tool_cmd
+		tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
+		test -x "$install_path/$tool_cmd" || fail "Expected $install_path/$tool_cmd to be executable."
+
+		echo "$TOOL_NAME $version installation was successful!"
+	) || (
+		rm -rf "$install_path"
+		fail "An error occurred while installing $TOOL_NAME $version."
+	)
+}

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-# TODO: Ensure this is the correct GitHub homepage where releases can be downloaded for <YOUR TOOL>.
 GH_REPO="https://github.com/digitalocean/doctl"
 TOOL_NAME="doctl"
 TOOL_TEST="doctl version"
@@ -39,12 +38,34 @@ download_release() {
 	local version filename url
 	version="$1"
 	filename="$2"
+	platform="$(get_platform)"
+	arch="$(get_arch)"
 
-	# TODO: Adapt the release URL convention for <YOUR TOOL>
-	url="$GH_REPO/archive/v${version}.tar.gz"
+	url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}-${version}-${platform}-${arch}.tar.gz"
 
 	echo "* Downloading $TOOL_NAME release $version..."
 	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
+}
+
+get_platform() {
+	local kernel
+	kernel="$(uname -s)"
+	if [[ ${OSTYPE} == "msys" || ${kernel} == "CYGWIN"* || ${kernel} == "MINGW"* ]]; then
+		echo windows
+	else
+		uname | tr '[:upper:]' '[:lower:]'
+	fi
+}
+
+get_arch() {
+    local arch
+		arch=$(uname -m)
+    if [ "$arch" = "x86_64" ]; then
+      arch="amd64"
+		elif [ "$arch" = "i686" ]; then
+		  arch="386"
+    fi
+    echo "${arch}"
 }
 
 install_version() {
@@ -60,7 +81,6 @@ install_version() {
 		mkdir -p "$install_path"
 		cp -r "$ASDF_DOWNLOAD_PATH"/* "$install_path"
 
-		# TODO: Assert <YOUR TOOL> executable exists.
 		local tool_cmd
 		tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
 		test -x "$install_path/$tool_cmd" || fail "Expected $install_path/$tool_cmd to be executable."

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -58,14 +58,14 @@ get_platform() {
 }
 
 get_arch() {
-    local arch
-		arch=$(uname -m)
-    if [ "$arch" = "x86_64" ]; then
-      arch="amd64"
-		elif [ "$arch" = "i686" ]; then
-		  arch="386"
-    fi
-    echo "${arch}"
+	local arch
+	arch=$(uname -m)
+	if [ "$arch" = "x86_64" ]; then
+		arch="amd64"
+	elif [ "$arch" = "i686" ]; then
+		arch="386"
+	fi
+	echo "${arch}"
 }
 
 install_version() {

--- a/scripts/format.bash
+++ b/scripts/format.bash
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+shfmt --language-dialect bash --write \
+	./**/*

--- a/scripts/lint.bash
+++ b/scripts/lint.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+shellcheck --shell=bash --external-sources \
+	bin/* --source-path=template/lib/ \
+	lib/* \
+	scripts/*
+
+shfmt --language-dialect bash --diff \
+	./**/*


### PR DESCRIPTION
This refactors everything to line up more like what the current asdf-vm/asdf-plugin-template repo looks.

- Logic moved to `lib/utils.bash`
- GitHub Actions over Travis CI
- Support i686 just because